### PR TITLE
Fix: Remove resource_owner_id in access token generation for compatib…

### DIFF
--- a/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
@@ -55,7 +55,7 @@ module Doorkeeper
         def generate_access_token_with_empty_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant.resource_owner_id,
+            device_grant,
             device_grant.scopes,
             {},
             server
@@ -65,7 +65,7 @@ module Doorkeeper
         def generate_access_token_without_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant.resource_owner_id,
+            device_grant,
             device_grant.scopes,
             server
           )


### PR DESCRIPTION
This change removes the use of `resource_owner_id` during access token generation to align with changes in Doorkeeper after [5.3.3](https://github.com/doorkeeper-gem/doorkeeper/blob/v5.3.3/lib/doorkeeper/oauth/authorization_code_request.rb) (line 38). Newer versions no longer rely on the resource owner's ID and instead expect the full `resource_owner` ActiveRecord object. This ensures the `doorkeeper-device_authorization_grant` gem remains compatible with the latest Doorkeeper versions.