### PR TITLE
Support polymorphic resource_owner in DeviceGrant

### DIFF
--- a/app/controllers/doorkeeper/device_authorization_grant/device_authorizations_controller.rb
+++ b/app/controllers/doorkeeper/device_authorization_grant/device_authorizations_controller.rb
@@ -21,13 +21,25 @@ module Doorkeeper
           next authorization_error_response(:invalid_user_code) if device_grant.nil?
           next authorization_error_response(:expired_user_code) if device_grant.expired?
 
-          device_grant.update!(user_code: nil, resource_owner_id: current_resource_owner.id)
+          device_grant.update!(grant_update_attributes)
 
           authorization_success_response
         end
       end
 
       private
+
+      def grant_update_attributes
+        attributes = { user_code: nil }
+
+        if Doorkeeper.configuration.polymorphic_resource_owner?
+          attributes[:resource_owner] = current_resource_owner
+        else
+          attributes[:resource_owner_id] = current_resource_owner.id
+        end
+
+        attributes
+      end
 
       def authorization_success_response
         respond_to do |format|

--- a/db/migrate/20200629094624_create_doorkeeper_device_grants.rb
+++ b/db/migrate/20200629094624_create_doorkeeper_device_grants.rb
@@ -3,7 +3,6 @@
 class CreateDoorkeeperDeviceGrants < ActiveRecord::Migration[6.0]
   def change
     create_table :oauth_device_grants do |t|
-      t.references :resource_owner, null: true
       t.references :application, null: false
       t.string :device_code, null: false
       t.string :user_code, null: true
@@ -11,6 +10,7 @@ class CreateDoorkeeperDeviceGrants < ActiveRecord::Migration[6.0]
       t.datetime :created_at, null: false
       t.datetime :last_polling_at, null: true
       t.string :scopes, null: false, default: ''
+      t.references :resource_owner, null: true
     end
 
     add_index :oauth_device_grants, :device_code, unique: true
@@ -24,5 +24,12 @@ class CreateDoorkeeperDeviceGrants < ActiveRecord::Migration[6.0]
 
     # Uncomment below to ensure a valid reference to the resource owner's table
     # add_foreign_key :oauth_device_grants, <model>, column: :resource_owner_id
+
+    # Uncomment the below if you're using a polymorphic association for resource owners.
+    # This allows oauth_device_grants to refer to different models (e.g., User, Admin).
+    # add_column :oauth_device_grants, :resource_owner_type, :string
+    # add_index :oauth_device_grants,
+    #   %i[resource_owner_id resource_owner_type],
+    #   name: 'index_oauth_device_grants_on_resource_owner'
   end
 end

--- a/lib/doorkeeper/device_authorization_grant/config.rb
+++ b/lib/doorkeeper/device_authorization_grant/config.rb
@@ -80,6 +80,11 @@ module Doorkeeper
         end
       )
 
+      # @!attribute [r] polymorphic_resource_owner
+      #   Determines if the resource owner association is polymorphic.
+      #   @return [Boolean]
+      option :polymorphic_resource_owner, default: false
+
       # @return [Class]
       def device_grant_model
         @device_grant_model ||= device_grant_class.constantize

--- a/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
@@ -55,7 +55,7 @@ module Doorkeeper
         def generate_access_token_with_empty_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant,
+            resource_owner,
             device_grant.scopes,
             {},
             server
@@ -65,10 +65,18 @@ module Doorkeeper
         def generate_access_token_without_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant,
+            resource_owner,
             device_grant.scopes,
             server
           )
+        end
+
+        def resource_owner
+          if Doorkeeper.config.polymorphic_resource_owner?
+            device_grant.resource_owner
+          else
+            device_grant.resource_owner_id
+          end
         end
 
         def check_grant_errors!

--- a/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
@@ -55,7 +55,7 @@ module Doorkeeper
         def generate_access_token_with_empty_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant.resource_owner_id,
+            device_grant,
             device_grant.scopes,
             {},
             server
@@ -65,7 +65,7 @@ module Doorkeeper
         def generate_access_token_without_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant.resource_owner_id,
+            device_grant,
             device_grant.scopes,
             server
           )

--- a/lib/doorkeeper/device_authorization_grant/orm/active_record/device_grant.rb
+++ b/lib/doorkeeper/device_authorization_grant/orm/active_record/device_grant.rb
@@ -7,11 +7,16 @@ module Doorkeeper
     class DeviceGrant < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord Doorkeeper models inherit from ActiveRecord::Base.
       include DeviceGrantMixin
 
+      belongs_to :resource_owner, polymorphic: -> { polymorphic_resource_owner? }
+
       # @!attribute application_id
       #   @return [Integer]
 
       # @!attribute resource_owner_id
       #   @return [Integer, nil]
+
+      # @!attribute resource_owner_type
+      #   @return [String, nil]
 
       # @!attribute expires_in
       #   @return [Integer]
@@ -30,6 +35,12 @@ module Doorkeeper
 
       # @!attribute last_polling_at
       #   @return [Time, nil]
+
+      private
+
+      def polymorphic_resource_owner?
+        Doorkeeper::DeviceAuthorizationGrant.configuration.polymorphic_resource_owner
+      end
     end
   end
 end

--- a/lib/generators/doorkeeper/device_authorization_grant/templates/initializer.rb
+++ b/lib/generators/doorkeeper/device_authorization_grant/templates/initializer.rb
@@ -30,4 +30,9 @@ Doorkeeper::DeviceAuthorizationGrant.configure do
   # verification_uri_complete ->(verification_uri, host_name, device_grant) do
   #   "#{verification_uri}?user_code=#{CGI.escape(device_grant.user_code)}"
   # end
+
+  # Associate device grants with multiple resource owner models.
+  # Set to true to allow associating device grants with multiple resource owner models.
+  # Set to false to use a single model like User.
+  # polymorphic_resource_owner false
 end

--- a/test/dummy/config/initializers/doorkeeper_device_authorization_grant.rb
+++ b/test/dummy/config/initializers/doorkeeper_device_authorization_grant.rb
@@ -30,4 +30,9 @@ Doorkeeper::DeviceAuthorizationGrant.configure do
   # verification_uri_complete ->(verification_uri, host_name, device_grant) do
   #   "#{verification_uri}?user_code=#{CGI.escape(device_grant.user_code)}"
   # end
+
+  # Associate device grants with multiple resource owner models.
+  # Set to true to allow associating device grants with multiple resource owner models.
+  # Set to false to use a single model like User.
+  # polymorphic_resource_owner false
 end


### PR DESCRIPTION
The applied change in this PR included the following changes:
- Refactored `resource_owner` assignment to support polymorphic associations via configuration.
- Updated `DeviceGrantsController` to use a helper method for conditional assignment.
- Added optional migration steps (commented) to support polymorphic associations.